### PR TITLE
add atom feed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@sveltejs/kit": "^1.0.0-next.324",
         "@typescript-eslint/eslint-plugin": "^5.15.0",
         "@typescript-eslint/parser": "^5.15.0",
+        "date-fns": "^2.28.0",
         "eslint": "^8.11.0",
         "eslint-plugin-svelte3": "^3.4.1",
         "prettier": "^2.6.2",
@@ -776,6 +777,19 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/debug": {
@@ -3204,6 +3218,12 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
+    },
+    "date-fns": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==",
+      "dev": true
     },
     "debug": {
       "version": "4.3.3",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@sveltejs/kit": "^1.0.0-next.324",
     "@typescript-eslint/eslint-plugin": "^5.15.0",
     "@typescript-eslint/parser": "^5.15.0",
+    "date-fns": "^2.28.0",
     "eslint": "^8.11.0",
     "eslint-plugin-svelte3": "^3.4.1",
     "prettier": "^2.6.2",

--- a/src/lib/BlogPostHeader.svelte
+++ b/src/lib/BlogPostHeader.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	import type {FeedItemData} from '$lib/feed';
+	import {formatDate} from '$lib/util';
+
+	export let post: FeedItemData;
+</script>
+
+<h1>{post.title}</h1>
+<p>
+	{formatDate(
+		post.date_modified,
+	)}{#if post.date_published && post.date_published !== post.date_modified}
+		{' '}— first published {formatDate(post.date_published)}
+	{/if}
+</p>

--- a/src/lib/feed.gen.ts
+++ b/src/lib/feed.gen.ts
@@ -1,0 +1,12 @@
+import type {Gen} from '@feltcoop/gro';
+
+import {feedData} from '$lib/feedData';
+import {toAtomXml} from '$lib/feed';
+
+const ATOM_FEED_PATH = `../static/feed.xml`;
+// TODO
+// const JSON_FEED_PATH = `../static/feed.json`;
+
+export const gen: Gen = async () => {
+	return [{content: toAtomXml(feedData), filename: ATOM_FEED_PATH, format: false}];
+};

--- a/src/lib/feed.ts
+++ b/src/lib/feed.ts
@@ -1,5 +1,7 @@
 /**
- * This is designed to extend JSON Feed 1.1 with other things like Atom namespaced.
+ * This is designed to extend JSON Feed 1.1 with namespaced data for other specs like Atom.
+ * It's still a work in progress, and I'll add features as I need them,
+ * and eventually this will be extracted to a standalone library.
  * https://www.jsonfeed.org/version/1.1/
  */
 export interface FeedData {

--- a/src/lib/feed.ts
+++ b/src/lib/feed.ts
@@ -1,0 +1,86 @@
+/**
+ * This is designed to extend JSON Feed 1.1 with other things like Atom namespaced.
+ * https://www.jsonfeed.org/version/1.1/
+ */
+export interface FeedData {
+	id: string;
+	title: string;
+	home_page_url: string;
+	description: string;
+	icon: string;
+	favicon: string;
+	author: {
+		name: string;
+		url?: string;
+		email?: string;
+	};
+	items: FeedItemData[];
+	atom: {
+		feed_url: string;
+	};
+	// TODO
+	// jsonfeed: {
+	// 	version: string;
+	// 	feed_url: string;
+	//  expired?: boolean;
+	// };
+}
+
+export interface FeedItemData {
+	id: string;
+	title: string;
+	url: string;
+	date_published: string;
+	date_modified: string;
+	summary: string;
+	// TODO
+	// content_text: string;
+	// content_html: string;
+	// image?: string;
+	// external_url?: string;
+	tags?: string[];
+}
+
+export const toAtomXml = (data: FeedData): string => {
+	const updated: string = data.items
+		.reduce((latest, item) => {
+			const modified = new Date(item.date_modified || item.date_published);
+			return modified > latest ? modified : latest;
+		}, new Date(0))
+		.toISOString();
+
+	return `<?xml version="1.0" encoding="UTF-8"?>
+
+<feed xmlns="http://www.w3.org/2005/Atom">
+
+  <id>${data.id}</id>
+  <title>${data.title}</title>
+  <subtitle>${data.description}</subtitle>
+  <link href="${data.home_page_url}" />
+  <link href="${data.atom.feed_url}" rel="self" type="application/atom+xml" />
+	<updated>${updated}</updated>
+  <icon>${data.icon}</icon>
+  <author>
+    <name>${data.author.name}</name>
+    ${data.author.email ? `<email>${data.author.email}</email>` : ''}
+    ${data.author.url ? `<uri>${data.author.url}</uri>` : ''}
+  </author>
+  ${data.items
+		.map(
+			(item) =>
+				`
+  <entry>
+    <id>${item.id}</id>
+    <title>${item.title}</title>
+    <link rel="alternate" href="${item.url}" />
+    <published>${item.date_published}</published>
+    <updated>${item.date_modified}</updated>
+    <summary>${item.summary}</summary>
+    ${item.tags ? item.tags.map((tag) => `<category term="${tag}" />`).join('') : ''}
+  </entry>`,
+		)
+		.join('\n')}
+
+</feed>
+`;
+};

--- a/src/lib/feedData.ts
+++ b/src/lib/feedData.ts
@@ -1,0 +1,30 @@
+import type {FeedData} from '$lib/feed';
+
+export const feedData: FeedData = {
+	title: 'Ryan Atkinson',
+	id: 'https://www.ryanatkn.com/',
+	home_page_url: 'https://www.ryanatkn.com/',
+	description: 'blog of a web developer making open source community software',
+	icon: 'https://www.ryanatkn.com/favicon.png',
+	favicon: 'https://www.ryanatkn.com/favicon.png',
+	author: {
+		name: 'Ryan Atkinson',
+		url: 'https://www.ryanatkn.com/',
+		email: 'mail@ryanatkn.com',
+	},
+	atom: {
+		feed_url: 'https://www.ryanatkn.com/feed.xml',
+	},
+	items: [
+		{
+			id: 'https://www.ryanatkn.com/blog/0',
+			title: 'A year of making open source web community software',
+			url: 'https://www.ryanatkn.com/blog/0',
+			date_published: '2022-05-13T01:42:23.000Z',
+			date_modified: '2022-05-13T01:42:23.000Z',
+			summary:
+				'I discuss my work on open source community software called Felt over the last year, giving a brief overview of the design and technology choices, and announcing our newsletter and podcast at FeltCoop.',
+			tags: ['web', 'technology', 'software', 'opensource', 'community'],
+		},
+	],
+};

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -1,0 +1,9 @@
+import {format} from 'date-fns';
+import {stripEnd, stripStart} from '@feltcoop/felt/util/string.js';
+
+// TODO rename?
+export const formatDate = (date: string | number | Date): string =>
+	format(typeof date === 'string' ? new Date(date) : date, 'PP');
+
+export const toPathname = (url: string, root: string): string =>
+	stripStart(url, stripEnd(root, '/'));

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -7,6 +7,12 @@
 <svelte:head>
 	<title>ryanatkn.com</title>
 	<link rel="icon" href="/favicon.png" />
+	<link
+		rel="alternate"
+		type="application/atom+xml"
+		title="Atom"
+		href="https://www.ryanatkn.com/feed.xml"
+	/>
 </svelte:head>
 
 <slot />

--- a/src/routes/blog/0.svelte
+++ b/src/routes/blog/0.svelte
@@ -2,6 +2,7 @@
 	import BlogPostHeader from '$lib/BlogPostHeader.svelte';
 	import {feedData} from '$lib/feedData';
 
+	// TODO refactor this probably, maybe putting the post in context
 	const post = feedData.items[0];
 </script>
 

--- a/src/routes/blog/0.svelte
+++ b/src/routes/blog/0.svelte
@@ -1,6 +1,12 @@
+<script lang="ts">
+	import BlogPostHeader from '$lib/BlogPostHeader.svelte';
+	import {feedData} from '$lib/feedData';
+
+	const post = feedData.items[0];
+</script>
+
 <div class="markup">
-	<h1>A year of making open source web community software</h1>
-	<p>2022 May</p>
+	<BlogPostHeader {post} />
 	<p>
 		I've been building an open source web project focused on community software with <a
 			href="https://twitter.com/greatbaconbits">Hamilton Reed</a
@@ -72,18 +78,6 @@
 						</li>
 					</ul>
 				</li>
-				<li>
-					both server and clients are open source and our APIs are open, so clients can be modified
-					and created from scratch
-				</li>
-				<li>
-					clients have a <a href="https://wikipedia.org/wiki/Client_(computing)#Thick">thickness</a>
-					optimized for UX over long sessions, which means a lot of JS and client-side caching, and thanks
-					to
-					<a href="https://kit.svelte.dev/">SvelteKit</a> we think we'll also be able to deliver good
-					experiences in many cases with fast loadtimes and minimal JS
-				</li>
-				<li>security and performance are unfortunate constraints and sometimes buzzkills :\</li>
 			</ul>
 		</li>
 	</ul>
@@ -241,6 +235,18 @@
 		it, and its flexibility is a wonder. We've been deprioritizing full SSR but it's a relief to
 		know it's there when we're ready for it. It's amazing how much of the load SvelteKit takes off
 		our shoulders.
+	</p>
+	<h3>customizable and extensible:</h3>
+	<p>
+		Both the server and clients are open source and our APIs are open, so clients can be modified or
+		created from scratch. We'll try to maximize the freedoms of users and developers, but security
+		and performance are unfortunate constraints and sometimes buzzkills :\
+	</p>
+	<p>
+		Our client has a <a href="https://wikipedia.org/wiki/Client_(computing)#Thick">thickness</a>
+		optimized for UX over long sessions, which means a lot of JS and client-side caching, and thanks
+		to SvelteKit we think we'll also be able to deliver good experiences in many cases with fast loadtimes
+		and minimal JS.
 	</p>
 	<h3>scaling (and not):</h3>
 	<p>

--- a/src/routes/blog/index.svelte
+++ b/src/routes/blog/index.svelte
@@ -1,24 +1,36 @@
 <script lang="ts">
+	import {feedData} from '$lib/feedData';
+	import {formatDate, toPathname} from '$lib/util';
 </script>
 
 <div class="blog">
 	<ol start="0">
-		<li>
-			<a href="/blog/0">A year of making open source web community software</a>
-			<small>2022 May</small>
-		</li>
+		{#each feedData.items as item}
+			<li>
+				<a href={toPathname(item.url, feedData.home_page_url)}>{item.title}</a>
+				<small>{formatDate(item.date_modified)}</small>
+			</li>
+		{/each}
 	</ol>
 </div>
 
 <style>
 	.blog {
 		display: flex;
-		align-items: flex-end;
-		justify-content: space-between;
-		flex-wrap: wrap;
+		flex-direction: column;
+		align-items: center;
 		padding: var(--spacing_xl3) 0;
 	}
 	li {
-		font-size: var(--font_size_xl2);
+		font-size: var(--font_size_lg);
+	}
+	a {
+		/* TODO hacky */
+		padding-left: var(--spacing_sm);
+	}
+	small {
+		white-space: nowrap;
+		font-size: var(--font_size_md);
+		padding-left: var(--spacing_sm);
 	}
 </style>

--- a/src/static/feed.xml
+++ b/src/static/feed.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<feed xmlns="http://www.w3.org/2005/Atom">
+
+  <id>https://www.ryanatkn.com/</id>
+  <title>Ryan Atkinson</title>
+  <subtitle>blog of a web developer making open source community software</subtitle>
+  <link href="https://www.ryanatkn.com/" />
+  <link href="https://www.ryanatkn.com/feed.xml" rel="self" type="application/atom+xml" />
+	<updated>2022-05-13T01:42:23.000Z</updated>
+  <icon>https://www.ryanatkn.com/favicon.png</icon>
+  <author>
+    <name>Ryan Atkinson</name>
+    <email>mail@ryanatkn.com</email>
+    <uri>https://www.ryanatkn.com/</uri>
+  </author>
+  
+  <entry>
+    <id>https://www.ryanatkn.com/blog/0</id>
+    <title>A year of making open source web community software</title>
+    <link rel="alternate" href="https://www.ryanatkn.com/blog/0" />
+    <published>2022-05-13T01:42:23.000Z</published>
+    <updated>2022-05-13T01:42:23.000Z</updated>
+    <summary>I discuss my work on open source community software called Felt over the last year, giving a brief overview of the design and technology choices, and announcing our newsletter and podcast at FeltCoop.</summary>
+    <category term="web" /><category term="technology" /><category term="software" /><category term="opensource" /><category term="community" />
+  </entry>
+
+</feed>


### PR DESCRIPTION
Adds an Atom feed for the blog. I chose to use [Gro's gen functionality](https://github.com/feltcoop/gro/blob/main/src/docs/gen.md) instead of a SvelteKit endpoint to give maximum visibility to the final XML file -- I'd like to track all changes in source control at least for the time being.

I based the data structure on [JSON Feed](https://www.jsonfeed.org/version/1.1/) and the plan is to make a library that supports Atom, JSON Feed, and RSS in one. (not because it doesn't exist, but I'd like to learn this stuff and have control over the details)